### PR TITLE
Attempting to fix circleci build due to missing docker_entrypoint.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: mkdir target && mv /tmp/workspace/*.jar target/gitlab-webhook.jar && mv /tmp/workspace/Dockerfile ./Dockerfile
+      - run: mkdir target && mv /tmp/workspace/*.jar target/gitlab-webhook.jar && mv /tmp/workspace/Dockerfile ./Dockerfile & mv /tmp/workspace/docker_entrypoint.sh ./docker_entrypoint.sh
       - run: |
           TAG=1.1.$CIRCLE_BUILD_NUM
           docker build -t sredna/gitlab-webhook:$TAG .


### PR DESCRIPTION
Hey Phil, hopefully this fixed the circleci build issue with misisng docker_entrypoint.sh.